### PR TITLE
Support for use_frameworks!

### DIFF
--- a/react-native-qonversion.podspec
+++ b/react-native-qonversion.podspec
@@ -21,6 +21,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,swift}"
   s.requires_arc = true
 
-  s.dependency "React"
+  s.dependency "React-Core"
   s.dependency "QonversionSandwich", "1.0.1"
 end


### PR DESCRIPTION
When using use_frameworks! which is required when using react-native-firebase, it results in build errors.  We need to change to "React-Core" to fix these build errors.