### PR TITLE
Update Sandwich SDK to 7.5.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -80,7 +80,7 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "io.qonversion:sandwich:7.4.0"
+  implementation "io.qonversion:sandwich:7.5.0"
 }
 
 if (isNewArchitectureEnabled()) {

--- a/qonversion-react-native-sdk.podspec
+++ b/qonversion-react-native-sdk.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,cpp,swift}"
   s.private_header_files = "ios/**/*.h"
 
-  s.dependency "QonversionSandwich", "7.4.0"
+  s.dependency "QonversionSandwich", "7.5.0"
   install_modules_dependencies(s)
 end


### PR DESCRIPTION
## Summary
- Update Sandwich SDK dependency to version 7.5.0

## Test plan
- [x] Build the SDK
- [x] Run sample app and verify basic functionality