### PR TITLE
Update example app to use DeferredPurchasesListener

### DIFF
--- a/example/src/screens/EntitlementsScreen/index.tsx
+++ b/example/src/screens/EntitlementsScreen/index.tsx
@@ -7,7 +7,7 @@ import {
   ScrollView,
   Platform,
 } from 'react-native';
-import Qonversion, { Entitlement } from '@qonversion/react-native-sdk';
+import Qonversion, { PurchaseResult } from '@qonversion/react-native-sdk';
 import Snackbar from 'react-native-snackbar';
 import { AppContext } from '../../store/AppStore';
 import SkeletonLoader from '../../components/SkeletonLoader';
@@ -37,22 +37,27 @@ const EntitlementsScreen: React.FC = () => {
     }
   };
 
-  const setEntitlementsListener = () => {
-    console.log('🔄 [Qonversion] Setting entitlements update listener...');
-    Qonversion.getSharedInstance().setEntitlementsUpdateListener({
-      onEntitlementsUpdated(entitlements: Map<string, Entitlement>) {
+  const setDeferredPurchasesListener = () => {
+    console.log('🔄 [Qonversion] Setting deferred purchases listener...');
+    Qonversion.getSharedInstance().setDeferredPurchasesListener({
+      onDeferredPurchaseCompleted(purchaseResult: PurchaseResult) {
         console.log(
-          '📡 [Qonversion] Entitlements updated via listener:',
-          Object.fromEntries(entitlements)
+          '📡 [Qonversion] Deferred purchase completed via listener:',
+          purchaseResult
         );
-        dispatch({ type: 'SET_ENTITLEMENTS', payload: entitlements });
+        if (purchaseResult.entitlements) {
+          dispatch({
+            type: 'SET_ENTITLEMENTS',
+            payload: purchaseResult.entitlements,
+          });
+        }
       },
     });
     console.log(
-      '✅ [Qonversion] Entitlements update listener set successfully'
+      '✅ [Qonversion] Deferred purchases listener set successfully'
     );
     Snackbar.show({
-      text: 'Entitlements listener set successfully!',
+      text: 'Deferred purchases listener set successfully!',
       duration: Snackbar.LENGTH_SHORT,
     });
   };
@@ -148,10 +153,10 @@ const EntitlementsScreen: React.FC = () => {
 
         <TouchableOpacity
           style={styles.button}
-          onPress={setEntitlementsListener}
+          onPress={setDeferredPurchasesListener}
         >
           <Text style={styles.buttonText}>
-            Set Entitlements Updated Listener
+            Set Deferred Purchases Listener
           </Text>
         </TouchableOpacity>
 


### PR DESCRIPTION
## Summary
- Replace the deprecated `setEntitlementsUpdateListener` with the new `setDeferredPurchasesListener` in the example app's `EntitlementsScreen`.
- Update the callback to consume `PurchaseResult` (reading `entitlements` from it) instead of a `Map<string, Entitlement>`.
- Rename the button label and handler to "Set Deferred Purchases Listener" so it matches the new API surface.

## Test plan
- [ ] Build and run the example app on iOS / Android.
- [ ] Tap "Set Deferred Purchases Listener" and confirm the snackbar appears.
- [ ] Trigger a deferred purchase (SCA / Ask to Buy / pending) and verify `onDeferredPurchaseCompleted` fires and the entitlements list updates.

Generated with [Claude Code](https://claude.com/claude-code)