### PR TITLE
Fix Kotlin compiler warnings (#439)

### DIFF
--- a/android/src/main/java/com/qonversion/reactnativesdk/QonversionModule.kt
+++ b/android/src/main/java/com/qonversion/reactnativesdk/QonversionModule.kt
@@ -299,7 +299,6 @@ class QonversionModule(reactContext: ReactApplicationContext) : NativeQonversion
         emitOnEntitlementsUpdated(mappedEntitlements)
     }
 
-    @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
     override fun onDeferredPurchaseCompleted(purchaseResult: BridgeData) {
         val mappedPurchaseResult = EntitiesConverter.convertMapToWritableMap(purchaseResult)
         emitOnDeferredPurchaseCompleted(mappedPurchaseResult)

--- a/android/src/main/java/com/qonversion/reactnativesdk/QonversionModule.kt
+++ b/android/src/main/java/com/qonversion/reactnativesdk/QonversionModule.kt
@@ -23,7 +23,7 @@ class QonversionModule(reactContext: ReactApplicationContext) : NativeQonversion
         (reactContext.applicationContext as Application),
         object : ActivityProvider {
             override val currentActivity: Activity?
-                get() = this@QonversionModule.currentActivity
+                get() = reactApplicationContext.currentActivity
         },
         this
     )
@@ -299,9 +299,9 @@ class QonversionModule(reactContext: ReactApplicationContext) : NativeQonversion
         emitOnEntitlementsUpdated(mappedEntitlements)
     }
 
-    override fun onDeferredPurchaseCompleted(purchaseResult: BridgeData) {
-        val mappedPurchaseResult = EntitiesConverter.convertMapToWritableMap(purchaseResult)
-        emitOnDeferredPurchaseCompleted(mappedPurchaseResult)
+    override fun onDeferredPurchaseCompleted(transaction: BridgeData) {
+        val mappedTransaction = EntitiesConverter.convertMapToWritableMap(transaction)
+        emitOnDeferredPurchaseCompleted(mappedTransaction)
     }
 
     companion object {

--- a/android/src/main/java/com/qonversion/reactnativesdk/QonversionModule.kt
+++ b/android/src/main/java/com/qonversion/reactnativesdk/QonversionModule.kt
@@ -299,9 +299,10 @@ class QonversionModule(reactContext: ReactApplicationContext) : NativeQonversion
         emitOnEntitlementsUpdated(mappedEntitlements)
     }
 
-    override fun onDeferredPurchaseCompleted(transaction: BridgeData) {
-        val mappedTransaction = EntitiesConverter.convertMapToWritableMap(transaction)
-        emitOnDeferredPurchaseCompleted(mappedTransaction)
+    @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+    override fun onDeferredPurchaseCompleted(purchaseResult: BridgeData) {
+        val mappedPurchaseResult = EntitiesConverter.convertMapToWritableMap(purchaseResult)
+        emitOnDeferredPurchaseCompleted(mappedPurchaseResult)
     }
 
     companion object {


### PR DESCRIPTION
## Summary

Fixes the React Native deprecation warning from #439 in `android/src/main/java/com/qonversion/reactnativesdk/QonversionModule.kt:26`.

`ActivityProvider.currentActivity` getter no longer references `BaseJavaModule.getCurrentActivity()` (deprecated in RN 0.80.0). Replaced `this@QonversionModule.currentActivity` with `reactApplicationContext.currentActivity`, which resolves to `ReactContext.getCurrentActivity()` (a Java method, not deprecated). This silences both the deprecation warning and the Kotlin synthetic-property warning.

The third warning from #439 (override-vs-supertype param-name mismatch on `onDeferredPurchaseCompleted`) is the symptom of `sandwich-sdk` declaring the supertype param as `transaction` while iOS and the RN bridge use `purchaseResult` (cross-platform-aligned, see commit 801d40d). That will be addressed at the root via a sandwich-sdk PR renaming the supertype param; this PR intentionally leaves the warning in place.

Single-file change, +1/-1.

Closes #439