### PR TITLE
Bridge No-Codes loadScreen, defaultVariables and custom action event (DEV-1188)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -80,7 +80,7 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "io.qonversion:sandwich:7.9.4"
+  implementation "io.qonversion:sandwich:7.10.1"
 }
 
 if (isNewArchitectureEnabled()) {

--- a/android/src/main/java/com/qonversion/reactnativesdk/NoCodesModule.kt
+++ b/android/src/main/java/com/qonversion/reactnativesdk/NoCodesModule.kt
@@ -81,6 +81,11 @@ class NoCodesModule(private val reactContext: ReactApplicationContext) : NativeN
     }
 
     @ReactMethod
+    override fun loadScreen(contextKey: String, promise: Promise) {
+        noCodesSandwich.loadScreen(contextKey, Utils.getResultListener(promise))
+    }
+
+    @ReactMethod
     override fun close(promise: Promise) {
         try {
             noCodesSandwich.close()

--- a/android/src/main/java/com/qonversion/reactnativesdk/NoCodesModule.kt
+++ b/android/src/main/java/com/qonversion/reactnativesdk/NoCodesModule.kt
@@ -82,7 +82,11 @@ class NoCodesModule(private val reactContext: ReactApplicationContext) : NativeN
 
     @ReactMethod
     override fun loadScreen(contextKey: String, promise: Promise) {
-        noCodesSandwich.loadScreen(contextKey, Utils.getResultListener(promise))
+        try {
+            noCodesSandwich.loadScreen(contextKey, Utils.getResultListener(promise))
+        } catch (e: Exception) {
+            promise.reject(e)
+        }
     }
 
     @ReactMethod

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,16 +8,16 @@ PODS:
   - hermes-engine (0.80.1):
     - hermes-engine/Pre-built (= 0.80.1)
   - hermes-engine/Pre-built (0.80.1)
-  - Qonversion (6.4.0):
-    - Qonversion/Main (= 6.4.0)
-  - qonversion-react-native-sdk (10.1.1):
+  - Qonversion (6.13.0):
+    - Qonversion/Main (= 6.13.0)
+  - qonversion-react-native-sdk (10.8.3):
     - boost
     - DoubleConversion
     - fast_float
     - fmt
     - glog
     - hermes-engine
-    - QonversionSandwich (= 7.4.0)
+    - QonversionSandwich (= 7.10.1)
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTRequired
@@ -40,9 +40,9 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - Qonversion/Main (6.4.0)
-  - QonversionSandwich (7.4.0):
-    - Qonversion (= 6.4.0)
+  - Qonversion/Main (6.13.0)
+  - QonversionSandwich (7.10.1):
+    - Qonversion (= 6.13.0)
   - RCT-Folly (2024.11.18.00):
     - boost
     - DoubleConversion
@@ -2437,78 +2437,78 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 4f07404533b808de66cf48ac4200463068d0e95a
-  Qonversion: f7620e1cc3b03541b9cf4a0ed357a5646d123fe3
-  qonversion-react-native-sdk: a0520e74e9840f14b110f806dd1e7cbd3d093fae
-  QonversionSandwich: 58a58f43664d2ddb755b315b51adfe9392ede3f9
+  Qonversion: 7c4ffeb6e6b23a248d370c47d82347fd6a18d175
+  qonversion-react-native-sdk: 2ba5d1cd813eaab9d3df1d028925f259b5073c58
+  QonversionSandwich: 72fda453eca4e322476172f8bc5b3e0e5368f2f0
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
   RCTDeprecation: efa5010912100e944a7ac9a93a157e1def1988fe
   RCTRequired: bbc4cf999ddc4a4b076e076c74dd1d39d0254630
   RCTTypeSafety: d877728097547d0a37786cc9130c43ad71739ac3
   React: 4b0b9cb962e694611e5e8a697c1b0300a2510c21
   React-callinvoker: 70f125c17c7132811a6b473946ac5e7ae93b5e57
-  React-Core: bab40f5b1f46fe0c5896895a6f333e861a821a81
-  React-CoreModules: 05647d952e521113c128360633896ba7ba652e82
-  React-cxxreact: 2b4bac1ec6eecc6288ac8a6caea6afb42585740e
+  React-Core: 7cbc3118df2334b2ef597d9a515938b02c82109f
+  React-CoreModules: 7d8c14ecb889e7786a04637583b55b7d8f246baf
+  React-cxxreact: f32be07cba236c2f20f4e05ca200577ba5358e78
   React-debug: deb3a146ef717fa3e8f4c23e0288369fe53199b7
-  React-defaultsnativemodule: 11e2948787a15d3cf1b66d7f29f13770a177bff7
-  React-domnativemodule: 2f4b279acdb2963736fb5de2f585811dd90070b5
-  React-Fabric: 6f8d1a303c96f1d078c14d74c4005bf457e5b782
-  React-FabricComponents: b106410970e9a0c4e592da656c7a7e0947306c23
-  React-FabricImage: 1abaf230dfce9b58fdf53c4128f3f40c6e64af6a
-  React-featureflags: f7ef58d91079efde3ad223bcca6d197e845d5bcf
-  React-featureflagsnativemodule: ae5abc9849d1696f4f8f11ee3744bf5715e032cf
-  React-graphics: b306856c6ed9aac32f717a229550406a53b28a6d
-  React-hermes: b6edce8fa19388654b1aea30844497cbeade83bc
-  React-idlecallbacksnativemodule: cb386712842cb9e479c89311edb234d529b64db4
-  React-ImageManager: 8ce94417853eaa22faaad1f4cc1952dd3f8e2275
-  React-jserrorhandler: ab827d67dc270a9c8703eef524230baeafaf6876
-  React-jsi: 545342ec5c78ab1277af5f0dbe8d489e7e73db14
-  React-jsiexecutor: 20210891c7c77255c16dec6762faf68b373f9f74
-  React-jsinspector: 4e73460e488132d70d2b4894e5578cc856f2cb74
-  React-jsinspectorcdp: 8b2bcb5779289cb2b9ca517f2965ed23eb2fd3e0
-  React-jsinspectornetwork: b5e0cb9e488d294eed2d8209dc3dc0f9587210c1
-  React-jsinspectortracing: f3c4036e7b984405ac910f878576d325dd9f2834
-  React-jsitooling: 75bbfd221b6173a5e848ca5a6680506bac064a56
-  React-jsitracing: 11ed7d821864dd988c159d4943e0a1e0937c11b1
-  React-logger: 984ebd897afad067555d081deaf03f57c4315723
-  React-Mapbuffer: 0c045c844ce6d85cde53e85ab163294c6adad349
-  React-microtasksnativemodule: d9499269ad1f484ae71319bac1d9231447f2094e
-  React-NativeModulesApple: 983f3483ef0a3446b56d490f09d579fba2442e17
+  React-defaultsnativemodule: 2c13a4240c5f96c42d069d1ba2392de6b4145bbd
+  React-domnativemodule: 91349b0b1cb20310cec1341b87cdd461aaa85e57
+  React-Fabric: bdfc7ec2481f26d7a9b8f59461f29ba4d903c549
+  React-FabricComponents: 47898469543d1bfb4528a9846419ec5568be89b1
+  React-FabricImage: ac8fc85ef452e5e9ae935c41118814651bd9e7f3
+  React-featureflags: 793b911e4c53e680db4a7d9965d0d6dc87b2fa88
+  React-featureflagsnativemodule: 25c9516d0dd004493c9bbafeb97da20bf9bde7dc
+  React-graphics: e07281690425dd9eeba3875d1faad28bc1f6da3b
+  React-hermes: bc1440d0e0662cc813bbf1c5ffbf9e0db2993a0f
+  React-idlecallbacksnativemodule: a2a3bb4a1793280b34d06d00169153b094be8c16
+  React-ImageManager: c9fa7461f3cab08e7bc98cbf55455b499e71c8b3
+  React-jserrorhandler: 15e591702040afed99cfcd088cf2337a8d09d807
+  React-jsi: 512ab3a1a628bc8824c41de8bcbbb81b2ac6fa8d
+  React-jsiexecutor: 653ccd2dee1e5ea558eecaf2f27b8bba0f09add8
+  React-jsinspector: 9121ccd2676a3f7c079ac01c9f90183422e3190e
+  React-jsinspectorcdp: 5c723ff2a09d73f2fdc496a545fb7003e7fdc079
+  React-jsinspectornetwork: 9cb0173f69e8405cef33fc79030fad26bbc3c073
+  React-jsinspectortracing: 65dc04125dc2392d85a82b6916f8cb088ea77566
+  React-jsitooling: 21af93cc98f760dd88d65b06b9317e0d4849fbbc
+  React-jsitracing: 4cc1b7de8087ae41c61a0eeee2593bc3362908b6
+  React-logger: 2f0d40bc8e648fbb1ff3b6580ad54189a8753290
+  React-Mapbuffer: 9a7c65078c6851397c1999068989e4fc239d0c80
+  React-microtasksnativemodule: 4f1ef719ba6c7ebbd2d75346ffa2916f9b4771c9
+  React-NativeModulesApple: f6f696e510b9d89c3c06b7764f56947dc13ae922
   React-oscompat: 114036cd8f064558c9c1a0c04fc9ae5e1453706a
-  React-perflogger: e7287fee27c16e3c8bd4d470f2361572b63be16b
-  React-performancetimeline: 8ebbaa31d2d0cea680b0a2a567500d3cab8954fc
+  React-perflogger: 4b2f88ae059b600daf268528a4a83366338eef05
+  React-performancetimeline: e15fd9798123436f99e46898422fe921fecf506b
   React-RCTActionSheet: 68c68b0a7a5d2b0cfc255c64889b6e485974e988
-  React-RCTAnimation: d6c5c728b888a967ce9aff1ff71a8ed71a68d069
-  React-RCTAppDelegate: 0fc048666bda159cd469a6fb9befb04b3fa62be4
-  React-RCTBlob: 12d8c699a1f906840113ee8d8bb575e69a05509f
-  React-RCTFabric: 01e815845ebc185f44205dcbf50eeb712fec23fe
-  React-RCTFBReactNativeSpec: f57927fb0af6ce2f25c19f8b894e2986138aa89f
-  React-RCTImage: a82518168f4ee407913b23ca749ca79ef51959f3
-  React-RCTLinking: 7f343b584c36f024f390fea563483568fe763ef6
-  React-RCTNetwork: 3165eb757ceb62a7cde4cdad043d63314122e8a3
-  React-RCTRuntime: feee590c459c4cb6aaa7a00f3abc8c04709b536f
-  React-RCTSettings: 6bad0ae45d8d872c873059f332f586f99875621f
-  React-RCTText: 657d60f35983062de8f0cea67c279aa7a3ea9858
-  React-RCTVibration: 78f4770515141efb7f55f9b27c49dda95319c3a8
+  React-RCTAnimation: 6bf502c89c53076f92cd1a254f5ec8d63ee263de
+  React-RCTAppDelegate: c90f5732784684c3dd226d812eccb578cd954ad7
+  React-RCTBlob: d2905f01749b80efd6d3b86fb15e30ed26d5450b
+  React-RCTFabric: 435b3ffaad113fb1f274c2f2a677c9fcc9b5cf55
+  React-RCTFBReactNativeSpec: a3178b419f42af196e90ca4bf07710dce5d68301
+  React-RCTImage: 8f5ffa03461339180a68820ea452af6e20ace2c7
+  React-RCTLinking: 1151646834d31f97580d8a75d768a84b2533b7f9
+  React-RCTNetwork: 52008724d0db90a540f4058ed0de0e41c4b7943c
+  React-RCTRuntime: 10ce9a7cb27ba307544d29a2a04e6202dc7b3e9a
+  React-RCTSettings: f724cacbd892ee18f985e1aebdd97386e49c76f5
+  React-RCTText: 6e1b95d9126d808410dfa96e09bc4441ec6f36f7
+  React-RCTVibration: 862a4e5b36d49e6299c8cbfb86486fc31f86f6fa
   React-rendererconsistency: f7baab26c6d0cd5b2eb7afcecfd2d8b957017b18
-  React-renderercss: bdd2f83a4a054c3e4321fd61305c202b848e471b
-  React-rendererdebug: 9f8865ee038127a9d99d4b034c9da4935d204993
+  React-renderercss: 62acb8f010a062309e3bd0e203aa14636162e3b3
+  React-rendererdebug: 3a89ac44f15c7160735264d585a29525655238d2
   React-rncore: f7438473c4c71ee1963fb06a8635bb96013c9e1c
-  React-RuntimeApple: 4d2ab9f72b9193da86eceded128a67254fc18aeb
-  React-RuntimeCore: 5fd73030438d094975ca0f549d162dd97746ae38
+  React-RuntimeApple: 81f0a9ba81ce7eb203529b0471dc69bf18f5f637
+  React-RuntimeCore: 6356e89b2518ba66a989c39a2adb18122a5e3b7b
   React-runtimeexecutor: 17c70842d5e611130cb66f91e247bc4a609c3508
-  React-RuntimeHermes: 3c88e6e1ea7ea0899dcffc77c10d61ea46688cfd
-  React-runtimescheduler: 024500621c7c93d65371498abb4ee26d34f5d47d
+  React-RuntimeHermes: 0a1d7ce2fe08cf182235de1a9330b51aa6b935cd
+  React-runtimescheduler: 10ae98e1417eff159be5df8fdc8fcdaac557aba6
   React-timing: c3c923df2b86194e1682e01167717481232f1dc7
-  React-utils: 9154a037543147e1c24098f1a48fc8472602c092
-  ReactAppDependencyProvider: afd905e84ee36e1678016ae04d7370c75ed539be
-  ReactCodegen: f8d5fb047c4cd9d2caade972cad9edac22521362
-  ReactCommon: 17fd88849a174bf9ce45461912291aca711410fc
-  RNCClipboard: b228d492733d66e0126e18ce66c6d2f90bacc7e5
-  RNSnackbar: c1b235eb606b03938c693ce769ed3059c31dff9b
+  React-utils: 7791a96e194eec85cb41dc98a2045b5f07839598
+  ReactAppDependencyProvider: ba631a31783569c13056dd57ff39e19764abdd6f
+  ReactCodegen: b16d00d43b4e9dc44af53be171b17d93b4b20267
+  ReactCommon: 96684b90b235d6ae340d126141edd4563b7a446a
+  RNCClipboard: acf8ae07037c21f17d9284ca56e982186ed21465
+  RNSnackbar: b0914bd060cdb82862dc1a987be57a8b918610bf
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 703055a9f39562521cdb8657162dfd80f8c174c3
 
 PODFILE CHECKSUM: af1f55bfb8d0c6c0a79cd9607de82ff807bedfbb
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/ios/RNNoCodes.mm
+++ b/ios/RNNoCodes.mm
@@ -75,6 +75,19 @@
     });
 }
 
+- (void)loadScreen:(NSString *)contextKey
+           resolve:(RCTPromiseResolveBlock)resolve
+            reject:(RCTPromiseRejectBlock)reject {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        @try {
+            [self.impl loadScreenWithContextKey:contextKey resolve:resolve reject:reject];
+        } @catch (NSException *exception) {
+            QNR_LOG_EXCEPTION("loadScreen", exception);
+            reject(@"QONBridgeException", exception.reason, nil);
+        }
+    });
+}
+
 - (void)close:(RCTPromiseResolveBlock)resolve
       reject:(RCTPromiseRejectBlock)reject {
     dispatch_async(dispatch_get_main_queue(), ^{

--- a/ios/RNNoCodesImpl.swift
+++ b/ios/RNNoCodesImpl.swift
@@ -81,6 +81,21 @@ public class RNNoCodesImpl: NSObject {
     }
 
     @MainActor @objc
+    public func loadScreen(contextKey: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        guard let noCodesSandwich else {
+            reject("SDKInitializationError", "No-Codes SDK is not initialized", nil)
+            return
+        }
+        noCodesSandwich.loadScreen(contextKey) { result, error in
+            if let error {
+                reject(error.code, error.details, nil)
+                return
+            }
+            resolve(result ?? [:])
+        }
+    }
+
+    @MainActor @objc
     public func close() {
         noCodesSandwich?.close()
     }

--- a/qonversion-react-native-sdk.podspec
+++ b/qonversion-react-native-sdk.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,cpp,swift}"
   s.private_header_files = "ios/**/*.h"
 
-  s.dependency "QonversionSandwich", "7.9.4"
+  s.dependency "QonversionSandwich", "7.10.1"
   install_modules_dependencies(s)
 end

--- a/src/NoCodesApi.ts
+++ b/src/NoCodesApi.ts
@@ -1,4 +1,5 @@
 import ScreenPresentationConfig from './dto/ScreenPresentationConfig';
+import type NoCodesScreen from './dto/NoCodesScreen';
 import type { NoCodesTheme } from './dto/enums';
 
 export default interface NoCodesApi {
@@ -18,6 +19,19 @@ export default interface NoCodesApi {
    *                        to the provided contextKey and only applied to that screen.
    */
   showScreen(contextKey: string, customVariables?: Record<string, string>): void;
+
+  /**
+   * Load a No-Code screen (from cache or network) without presenting it, so you can decide
+   * whether to present it or show your own fallback UI before any SDK screen appears.
+   * Present the screen with {@link showScreen} — the loaded content is served from cache.
+   *
+   * The returned {@link NoCodesScreen} exposes the typed default variables configured
+   * in the builder and the default selected product id.
+   *
+   * @param contextKey the context key of the screen to load.
+   * @returns the loaded screen data.
+   */
+  loadScreen(contextKey: string): Promise<NoCodesScreen>;
 
   /**
    * Close the current opened No-Code screen.

--- a/src/dto/NoCodesListener.ts
+++ b/src/dto/NoCodesListener.ts
@@ -27,6 +27,18 @@ export interface NoCodesListener {
     onActionFinishedExecuting: (action: NoCodesAction) => void;
 
     /**
+     * Called when a custom action configured in the builder is triggered on the screen.
+     * The No-Codes SDK does not execute anything itself — handle the value in your app code.
+     * The screen stays open; close it using {@link NoCodesApi.close} if needed.
+     *
+     * Optional to keep existing listener implementations source-compatible.
+     *
+     * @param value the string value configured for the custom action in the builder,
+     * or an empty string if no value was configured
+     */
+    onCustomAction?: (value: string) => void;
+
+    /**
      * Called when No-Codes flow is finished
      */
     onFinished: () => void;

--- a/src/dto/NoCodesScreen.ts
+++ b/src/dto/NoCodesScreen.ts
@@ -1,0 +1,116 @@
+import { NoCodesScreenVariableKind } from './enums';
+
+/**
+ * A typed default variable of a No-Codes screen, configured in the builder and delivered
+ * at screen load so it can be read by key. The value keeps its authored type
+ * (boolean / string / number) rather than being coerced to a string.
+ */
+export class NoCodesScreenVariable {
+  /**
+   * What the variable represents — see {@link NoCodesScreenVariableKind}.
+   */
+  kind: NoCodesScreenVariableKind;
+
+  /**
+   * Variable name it is addressed by (`variable.<key>` in the builder for custom
+   * variables, the slot name for product slots). May contain spaces.
+   */
+  key: string;
+
+  /**
+   * Authored value type: `"boolean"`, `"string"` or `"number"`.
+   */
+  type: string;
+
+  /**
+   * The configured default value, preserving its native type.
+   * Null when no default value was authored.
+   */
+  value: boolean | string | number | null;
+
+  /**
+   * The value rendered as a plain string regardless of its native type: `"true"`/`"false"`
+   * for booleans, the string itself, a number without a trailing `.0` when integral,
+   * or an empty string when no value was authored.
+   */
+  stringValue: string;
+
+  constructor(
+    kind: NoCodesScreenVariableKind,
+    key: string,
+    type: string,
+    value: boolean | string | number | null,
+    stringValue: string
+  ) {
+    this.kind = kind;
+    this.key = key;
+    this.type = type;
+    this.value = value;
+    this.stringValue = stringValue;
+  }
+}
+
+/**
+ * A loaded No-Codes screen returned from {@link NoCodesApi.loadScreen}.
+ *
+ * Exposes the screen identifiers and the typed default variables configured in the builder —
+ * the screen content stays internal, as rendering remains the SDK's job via
+ * {@link NoCodesApi.showScreen}.
+ */
+class NoCodesScreen {
+  /**
+   * Identifier of the screen.
+   */
+  id: string;
+
+  /**
+   * The context key of the screen set in the No-Codes builder.
+   */
+  contextKey: string;
+
+  /**
+   * The Qonversion product id selected by default when the screen opens (the builder's
+   * Default Product), or undefined when none is configured.
+   */
+  defaultSelectedProductId: string | undefined;
+
+  /**
+   * Typed default variables of the screen configured in the builder: authored custom
+   * variables and product slots. Read them by {@link NoCodesScreenVariable.key} (may be empty).
+   */
+  defaultVariables: NoCodesScreenVariable[];
+
+  constructor(
+    id: string,
+    contextKey: string,
+    defaultSelectedProductId: string | undefined,
+    defaultVariables: NoCodesScreenVariable[]
+  ) {
+    this.id = id;
+    this.contextKey = contextKey;
+    this.defaultSelectedProductId = defaultSelectedProductId;
+    this.defaultVariables = defaultVariables;
+  }
+
+  /**
+   * Returns the default variable configured under the given key, or undefined when the screen
+   * has no variable with that exact (case-sensitive) key.
+   *
+   * Keys are only unique within a kind — a custom variable and a product slot may share a
+   * name — so pass `kind` to disambiguate; without it the first match in payload order
+   * (custom variables, then product slots, then the selected product) is returned.
+   *
+   * For the default selected product prefer {@link defaultSelectedProductId} — it needs no key.
+   */
+  defaultVariable(
+    key: string,
+    kind?: NoCodesScreenVariableKind
+  ): NoCodesScreenVariable | undefined {
+    return this.defaultVariables.find(
+      (variable) =>
+        variable.key === key && (kind === undefined || variable.kind === kind)
+    );
+  }
+}
+
+export default NoCodesScreen;

--- a/src/dto/enums.ts
+++ b/src/dto/enums.ts
@@ -408,7 +408,8 @@ export enum NoCodesErrorCode {
   PRODUCTS_LOADING_FAILED = "ProductsLoadingFailed", // iOS
   RATE_LIMIT_EXCEEDED = "RateLimitExceeded", // iOS
   SCREEN_LOADING_FAILED = "ScreenLoadingFailed", // iOS
-  SDK_INITIALIZATION_ERROR = "SDKInitializationError" // iOS
+  SDK_INITIALIZATION_ERROR = "SDKInitializationError", // iOS
+  CLIENT_ERROR = "ClientError"
 }
 
 /**

--- a/src/dto/enums.ts
+++ b/src/dto/enums.ts
@@ -412,6 +412,35 @@ export enum NoCodesErrorCode {
 }
 
 /**
+ * Kind of a No-Codes screen default variable — what it was configured as in the builder.
+ * The set may grow in future backend versions; values this SDK version does not know
+ * are mapped to {@link NoCodesScreenVariableKind.UNKNOWN} instead of failing.
+ */
+export enum NoCodesScreenVariableKind {
+  /**
+   * A Screen Variable authored in the builder's Variables section.
+   */
+  CUSTOM = "custom",
+
+  /**
+   * A product slot: the variable key is the slot name and the value is the default
+   * Qonversion product id assigned to it.
+   */
+  PRODUCT = "product",
+
+  /**
+   * The screen's Default Product configured in the builder: the value is
+   * the Qonversion product id selected by default.
+   */
+  SELECTED_PRODUCT = "selected_product",
+
+  /**
+   * A kind introduced on the backend after this SDK version was released.
+   */
+  UNKNOWN = "unknown",
+}
+
+/**
  * Status of the purchase result.
  */
 export enum PurchaseResultStatus {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,3 +45,4 @@ export type { NoCodesListener } from './dto/NoCodesListener';
 export type { PurchaseDelegate } from './dto/PurchaseDelegate';
 export { default as NoCodesAction } from './dto/NoCodesAction';
 export { default as NoCodesError } from './dto/NoCodesError';
+export { default as NoCodesScreen, NoCodesScreenVariable } from './dto/NoCodesScreen';

--- a/src/internal/Mapper.ts
+++ b/src/internal/Mapper.ts
@@ -1171,6 +1171,7 @@ class Mapper {
       case NoCodesErrorCode.RATE_LIMIT_EXCEEDED: return NoCodesErrorCode.RATE_LIMIT_EXCEEDED;
       case NoCodesErrorCode.SCREEN_LOADING_FAILED: return NoCodesErrorCode.SCREEN_LOADING_FAILED;
       case NoCodesErrorCode.SDK_INITIALIZATION_ERROR: return NoCodesErrorCode.SDK_INITIALIZATION_ERROR;
+      case NoCodesErrorCode.CLIENT_ERROR: return NoCodesErrorCode.CLIENT_ERROR;
     }
 
     return NoCodesErrorCode.UNKNOWN;

--- a/src/internal/Mapper.ts
+++ b/src/internal/Mapper.ts
@@ -22,6 +22,7 @@ import {
   TransactionType,
   UserPropertyKey,
   NoCodesErrorCode,
+  NoCodesScreenVariableKind,
   ActionType,
 } from "../dto/enums";
 import IntroEligibility from "../dto/IntroEligibility";
@@ -52,6 +53,7 @@ import ProductInstallmentPlanDetails from '../dto/storeProducts/ProductInstallme
 import PromotionalOffer from '../dto/PromotionalOffer';
 import SKPaymentDiscount from '../dto/storeProducts/SKPaymentDiscount';
 import NoCodesAction from '../dto/NoCodesAction';
+import NoCodesScreen, {NoCodesScreenVariable} from '../dto/NoCodesScreen';
 import QonversionError from '../dto/QonversionError';
 import NoCodesError from '../dto/NoCodesError';
 import PurchaseResult from '../dto/PurchaseResult';
@@ -301,6 +303,23 @@ export type QNoCodesError = QQonversionError & {
 };
 
 export type QNoCodeScreenInfo = { screenId: string };
+
+export type QNoCodeCustomActionInfo = { value?: string | null };
+
+export type QScreenVariable = {
+  kind?: string | null;
+  key: string;
+  type: string;
+  value?: boolean | string | number | null;
+  stringValue?: string | null;
+};
+
+export type QNoCodeScreen = {
+  id: string;
+  contextKey: string;
+  defaultSelectedProductId?: string | null;
+  defaultVariables?: QScreenVariable[] | null;
+};
 
 export type QStoreTransaction = {
   transactionId?: string | null;
@@ -1060,6 +1079,33 @@ class Mapper {
       payload["parameters"],
       this.convertNoCodesError(payload["error"])
     );
+  }
+
+  static convertScreen(
+    payload: QNoCodeScreen
+  ): NoCodesScreen {
+    const variables = (payload.defaultVariables ?? []).map(variable => new NoCodesScreenVariable(
+      this.convertScreenVariableKind(variable.kind),
+      variable.key,
+      variable.type,
+      variable.value ?? null,
+      variable.stringValue ?? "",
+    ));
+    return new NoCodesScreen(
+      payload.id,
+      payload.contextKey,
+      payload.defaultSelectedProductId ?? undefined,
+      variables,
+    );
+  }
+
+  static convertScreenVariableKind(kind: string | null | undefined): NoCodesScreenVariableKind {
+    switch (kind) {
+      case NoCodesScreenVariableKind.CUSTOM: return NoCodesScreenVariableKind.CUSTOM;
+      case NoCodesScreenVariableKind.PRODUCT: return NoCodesScreenVariableKind.PRODUCT;
+      case NoCodesScreenVariableKind.SELECTED_PRODUCT: return NoCodesScreenVariableKind.SELECTED_PRODUCT;
+      default: return NoCodesScreenVariableKind.UNKNOWN;
+    }
   }
 
   static convertNoCodesError(

--- a/src/internal/NoCodesInternal.ts
+++ b/src/internal/NoCodesInternal.ts
@@ -1,10 +1,11 @@
 import type NoCodesApi from "../NoCodesApi";
 import NoCodesConfig from "../NoCodesConfig";
-import Mapper, { type QNoCodeAction, type QNoCodesError, type QNoCodeScreenInfo, type QProduct } from "./Mapper";
+import Mapper, { type QNoCodeAction, type QNoCodeCustomActionInfo, type QNoCodesError, type QNoCodeScreen, type QNoCodeScreenInfo, type QProduct } from "./Mapper";
 import type {NoCodesListener} from '../dto/NoCodesListener';
 import type {PurchaseDelegate} from '../dto/PurchaseDelegate';
 import ScreenPresentationConfig from '../dto/ScreenPresentationConfig';
 import NoCodesError from '../dto/NoCodesError';
+import NoCodesScreen from '../dto/NoCodesScreen';
 import {NoCodesErrorCode, NoCodesTheme} from '../dto/enums';
 import RNNoCodes from './specs/NativeNoCodesModule';
 import {sdkSource, sdkVersion} from './QonversionInternal';
@@ -21,6 +22,7 @@ const EVENT_ACTION_STARTED = "nocodes_action_started";
 const EVENT_ACTION_FAILED = "nocodes_action_failed";
 const EVENT_ACTION_FINISHED = "nocodes_action_finished";
 const EVENT_SCREEN_FAILED_TO_LOAD = "nocodes_screen_failed_to_load";
+const EVENT_CUSTOM_ACTION = "nocodes_custom_action";
 
 export default class NoCodesInternal implements NoCodesApi {
   private noCodesListener: NoCodesListener | null = null;
@@ -47,6 +49,11 @@ export default class NoCodesInternal implements NoCodesApi {
     await RNNoCodes.showScreen(contextKey, customVariables);
   }
 
+  async loadScreen(contextKey: string): Promise<NoCodesScreen> {
+    const screenData = await RNNoCodes.loadScreen(contextKey);
+    return Mapper.convertScreen(screenData as QNoCodeScreen);
+  }
+
   async close() {
     await RNNoCodes.close();
   }
@@ -69,6 +76,10 @@ export default class NoCodesInternal implements NoCodesApi {
       case EVENT_ACTION_FINISHED:
         const actionFinished = Mapper.convertAction(event.payload as QNoCodeAction);
         this.noCodesListener?.onActionFinishedExecuting(actionFinished);
+        break;
+      case EVENT_CUSTOM_ACTION:
+        const value = (event.payload as QNoCodeCustomActionInfo | undefined)?.value ?? "";
+        this.noCodesListener?.onCustomAction?.(value);
         break;
       case EVENT_FINISHED:
         this.noCodesListener?.onFinished();

--- a/src/internal/NoCodesInternal.ts
+++ b/src/internal/NoCodesInternal.ts
@@ -13,7 +13,7 @@ import Product from '../dto/Product';
 
 type NoCodeEvent = {
   name: string;
-  payload: QNoCodeAction | QNoCodesError | QNoCodeScreenInfo | undefined;
+  payload: QNoCodeAction | QNoCodesError | QNoCodeScreenInfo | QNoCodeCustomActionInfo | undefined;
 };
 
 const EVENT_SCREEN_SHOWN = "nocodes_screen_shown";

--- a/src/internal/specs/NativeNoCodesModule.ts
+++ b/src/internal/specs/NativeNoCodesModule.ts
@@ -6,6 +6,7 @@ export interface Spec extends TurboModule {
   initialize(projectKey: string, source: string, version: string, proxyUrl?: string, locale?: string, theme?: string): void;
   setScreenPresentationConfig(configData: Object, contextKey?: string): Promise<boolean>;
   showScreen(contextKey: string, customVariables?: { [key: string]: string }): Promise<boolean>;
+  loadScreen(contextKey: string): Promise<Object>;
   close(): Promise<boolean>;
   setPurchaseDelegate(): void;
   setLocale(locale: string | null): void;


### PR DESCRIPTION
Brings the No-Codes API from sandwich **7.10.1** (native iOS 6.13.0 / Android nocodes 1.10.0) into the RN layer.

[DEV-1188](https://linear.app/qonversion/issue/DEV-1188/react-native-no-codes-loadscreen-defaultvariables-and-custom-action)

## Changes
- Sandwich bump 7.9.4 → **7.10.1** (podspec + gradle).
- `NoCodes.loadScreen(contextKey): Promise<NoCodesScreen>` — load-before-present; the screen model exposes `id`, `contextKey`, `defaultSelectedProductId` and typed `defaultVariables` (`kind: custom|product|selected_product|unknown`, typed `value` + `stringValue`) with a `defaultVariable(key, kind?)` lookup mirroring the native SDKs. Presenting stays on `showScreen` (served from cache).
- New `nocodes_custom_action` event → **optional** `onCustomAction(value)` callback on `NoCodesListener` (optional keeps existing listeners source-compatible).
- TurboModule spec: new `loadScreen` method; iOS bridges via sandwich `BridgeCompletion` → promise, Android via `Utils.getResultListener`.

## Verification
- `yarn typecheck` ✅, `yarn test` ✅ (10/10), eslint on the new file ✅ (repo-wide prettier debt untouched)
- Android codegen (`generateCodegenArtifactsFromSchema`) ✅ + `:qonversion_react-native-sdk:compileDebugKotlin` ✅ against sandwich 7.10.1
- iOS example build against pod 7.10.1 — running, will report in a comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQEJXqfVNxqoUcKXhSPhWn