### PR TITLE
chore: deprecate public Offerings API

### DIFF
--- a/src/QonversionApi.ts
+++ b/src/QonversionApi.ts
@@ -111,9 +111,10 @@ export interface QonversionApi {
    * set of products with discounts later on if a user has not converted.
    * Offerings allow changing the products offered remotely without releasing app updates.
    *
+   * @deprecated Offerings are deprecated. Manage paywall products with Remote Configs instead: https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs
    * @returns the promise with Qonversion offerings
    *
-   * @see [Offerings](https://qonversion.io/docs/offerings) for more details
+   * @see [Migrate Offerings to Remote Configs](https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs) for more details
    */
   offerings(): Promise<Offerings | null>;
 

--- a/src/internal/QonversionInternal.ts
+++ b/src/internal/QonversionInternal.ts
@@ -246,6 +246,10 @@ export default class QonversionInternal implements QonversionApi {
     return mappedProducts;
   }
 
+  /**
+   * @deprecated Offerings are deprecated. Manage paywall products with Remote Configs instead: https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs
+   * @see [Migrate Offerings to Remote Configs](https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs) for more details
+   */
   async offerings(): Promise<Offerings | null> {
     let offerings = await RNQonversion.offerings();
     const mappedOfferings = Mapper.convertOfferings(offerings);


### PR DESCRIPTION
## Summary

Offerings are a legacy Qonversion feature that has been superseded by **Remote Configs**. This PR marks the public Offerings API as deprecated so integrators are guided toward the replacement.

- Add `@deprecated` JSDoc tag to `offerings()` on the `QonversionApi` interface (`src/QonversionApi.ts`) and its `QonversionInternal` implementation (`src/internal/QonversionInternal.ts`).
- Repoint the doc-comment `@see` link from the old Offerings page to the migration guide.

## Behavior

No runtime behavior changes. This is a documentation-only deprecation — the method continues to work exactly as before. No version bump or CHANGELOG edits are included.

## Migration

Manage paywall products with Remote Configs instead: https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs

## Related

- documentation_mintlify#100
- dash-mono#571

🤖 Generated with [Claude Code](https://claude.com/claude-code)
