### PR TITLE
DEV-1215: expose purchaseOptionId on Product

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -80,7 +80,7 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "io.qonversion:sandwich:7.10.1"
+  implementation "io.qonversion:sandwich:7.11.0"
 }
 
 if (isNewArchitectureEnabled()) {

--- a/qonversion-react-native-sdk.podspec
+++ b/qonversion-react-native-sdk.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,cpp,swift}"
   s.private_header_files = "ios/**/*.h"
 
-  s.dependency "QonversionSandwich", "7.10.1"
+  s.dependency "QonversionSandwich", "7.11.0"
   install_modules_dependencies(s)
 end

--- a/src/dto/Product.ts
+++ b/src/dto/Product.ts
@@ -11,9 +11,16 @@ class Product {
   storeId: string | null;
 
   /**
-   * Identifier of the base plan for Google product.
+   * Identifier of the base plan for a Google Play subscription product.
+   * Android only. Null for one-time products - use {@link purchaseOptionId} for those.
    */
   basePlanId: string | null;
+
+  /**
+   * Identifier of the Google Play purchase option for a one-time (in-app) product.
+   * Android only. Null for subscription products - use {@link basePlanId} for those.
+   */
+  purchaseOptionId: string | null;
 
   /**
    * Google Play Store details of this product.
@@ -66,6 +73,7 @@ class Product {
     qonversionId: string,
     storeId: string,
     basePlanId: string | null,
+    purchaseOptionId: string | null,
     storeDetails: ProductStoreDetails | null,
     skProduct: SKProduct | null,
     offeringId: string | null,
@@ -82,6 +90,7 @@ class Product {
     this.qonversionId = qonversionId;
     this.storeId = storeId;
     this.basePlanId = basePlanId;
+    this.purchaseOptionId = purchaseOptionId;
     this.storeDetails = storeDetails;
     this.skProduct = skProduct;
     this.offeringId = offeringId;

--- a/src/dto/storeProducts/ProductStoreDetails.ts
+++ b/src/dto/storeProducts/ProductStoreDetails.ts
@@ -8,10 +8,16 @@ import ProductInAppDetails from "./ProductInAppDetails";
  */
 class ProductStoreDetails {
   /**
-   * Identifier of the base plan to which these details relate.
-   * Null for in-app products.
+   * Identifier of the base plan for a Google Play subscription product.
+   * Null for one-time products - use {@link purchaseOptionId} for those.
    */
   basePlanId: string | null;
+
+  /**
+   * Identifier of the Google Play purchase option for a one-time (in-app) product.
+   * Null for subscription products - use {@link basePlanId} for those.
+   */
+  purchaseOptionId: string | null;
 
   /**
    * Identifier of the subscription or the in-app product.
@@ -111,6 +117,7 @@ class ProductStoreDetails {
 
   constructor(
     basePlanId: string | null,
+    purchaseOptionId: string | null,
     productId: string,
     name: string,
     title: string,
@@ -129,6 +136,7 @@ class ProductStoreDetails {
     isInstallment: boolean,
   ) {
     this.basePlanId = basePlanId;
+    this.purchaseOptionId = purchaseOptionId;
     this.productId = productId;
     this.name = name;
     this.title = title;

--- a/src/internal/Mapper.ts
+++ b/src/internal/Mapper.ts
@@ -75,6 +75,7 @@ export type QProduct = {
 
 type QProductStoreDetails = {
   basePlanId?: string | null,
+  purchaseOptionId?: string | null,
   productId: string,
   name: string,
   title: string
@@ -879,6 +880,7 @@ class Mapper {
 
     return new ProductStoreDetails(
       productStoreDetails.basePlanId ?? null,
+      productStoreDetails.purchaseOptionId ?? null,
       productStoreDetails.productId,
       productStoreDetails.name,
       productStoreDetails.title,

--- a/src/internal/Mapper.ts
+++ b/src/internal/Mapper.ts
@@ -63,6 +63,7 @@ export type QProduct = {
   id: string;
   storeId: string;
   basePlanId?: string | null;
+  purchaseOptionId?: string | null;
   type: string;
   subscriptionPeriod?: QSubscriptionPeriod | null;
   trialPeriod?: QSubscriptionPeriod | null;
@@ -622,6 +623,7 @@ class Mapper {
       product.id,
       product.storeId,
       product.basePlanId ?? null,
+      product.purchaseOptionId ?? null,
       storeDetails,
       skProduct,
       offeringId,


### PR DESCRIPTION
Issue: [DEV-1215](https://linear.app/qonversion/issue/DEV-1215)

Add a dedicated `purchaseOptionId` field for one-time products, parsed from the native bridge map, mirroring `basePlanId`. `basePlanId` now carries the subscription base plan only (null for one-time); `purchaseOptionId` carries the one-time purchase option (null for subscriptions).

Runtime chain: native (android-sdk #847) → sandwich (#352, must emit the key) → this wrapper. Wrapper code is self-contained (TypeScript); the value populates once the bundled sandwich emits `purchaseOptionId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)