### PR TITLE
feat: expose invalidateRemoteConfigsCache, bump sandwich to 7.12.0 (DEV-1236)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -80,7 +80,7 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "io.qonversion:sandwich:7.11.0"
+  implementation "io.qonversion:sandwich:7.12.0"
 }
 
 if (isNewArchitectureEnabled()) {

--- a/android/src/main/java/com/qonversion/reactnativesdk/QonversionModule.kt
+++ b/android/src/main/java/com/qonversion/reactnativesdk/QonversionModule.kt
@@ -247,6 +247,11 @@ class QonversionModule(reactContext: ReactApplicationContext) : NativeQonversion
     }
 
     @ReactMethod
+    override fun invalidateRemoteConfigsCache() {
+        qonversionSandwich.invalidateRemoteConfigsCache()
+    }
+
+    @ReactMethod
     override fun attachUserToExperiment(experimentId: String, groupId: String, promise: Promise) {
         qonversionSandwich.attachUserToExperiment(experimentId, groupId, getResultListener(promise))
     }

--- a/ios/RNQonversion.mm
+++ b/ios/RNQonversion.mm
@@ -258,6 +258,14 @@
     }
 }
 
+- (void)invalidateRemoteConfigsCache {
+    @try {
+        [self.impl invalidateRemoteConfigsCache];
+    } @catch (NSException *exception) {
+        QNR_LOG_EXCEPTION("invalidateRemoteConfigsCache", exception);
+    }
+}
+
 - (void)attachUserToExperiment:(NSString *)experimentId groupId:(NSString *)groupId resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
     @try {
         [self.impl attachUserToExperiment:experimentId groupId:groupId resolve:resolve reject:reject];

--- a/ios/RNQonversionImpl.swift
+++ b/ios/RNQonversionImpl.swift
@@ -197,6 +197,11 @@ public class RNQonversionImpl: NSObject {
   }
 
   @objc
+  public func invalidateRemoteConfigsCache() {
+    qonversionSandwich?.invalidateRemoteConfigsCache()
+  }
+
+  @objc
   public func attachUserToExperiment(_ experimentId: String, groupId: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
     qonversionSandwich?.attachUserToExperiment(with: experimentId, groupId: groupId) { result, error in
       self.handleResult(result: result, error: error, resolve: resolve, reject: reject)

--- a/qonversion-react-native-sdk.podspec
+++ b/qonversion-react-native-sdk.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,cpp,swift}"
   s.private_header_files = "ios/**/*.h"
 
-  s.dependency "QonversionSandwich", "7.11.0"
+  s.dependency "QonversionSandwich", "7.12.0"
   install_modules_dependencies(s)
 end

--- a/src/QonversionApi.ts
+++ b/src/QonversionApi.ts
@@ -338,7 +338,14 @@ export interface QonversionApi {
    * immediately, for example after setting a batch of user properties your
    * remote config targeting depends on. You do NOT need to call it after
    * {@link identify} — the SDK invalidates the cache on identity changes
-   * automatically. Call it after {@link initialize}.
+   * automatically.
+   *
+   * If the re-issued load fails, the previously received evaluation is
+   * delivered instead of an error — the call never degrades below the
+   * pre-invalidation result.
+   *
+   * Call it after {@link Qonversion.initialize}: calling before initialization
+   * throws on Android and does nothing on iOS.
    */
   invalidateRemoteConfigsCache(): void;
 

--- a/src/QonversionApi.ts
+++ b/src/QonversionApi.ts
@@ -325,6 +325,24 @@ export interface QonversionApi {
   remoteConfigListForContextKeys(contextKeys: string[], includeEmptyContextKey: boolean): Promise<RemoteConfigList>
 
   /**
+   * Invalidates the cache of remote configs so the next {@link remoteConfig} or
+   * {@link remoteConfigList} call fetches a fresh targeting evaluation from the
+   * server instead of returning the cached copy.
+   *
+   * This method performs no network request itself — it only marks the cached
+   * values as stale. An in-flight remoteConfig load is re-issued once so its
+   * waiting calls receive a fresh evaluation; an in-flight remoteConfigList
+   * completes with the evaluation it started with.
+   *
+   * Call it when the targeting inputs changed and you need the change reflected
+   * immediately, for example after setting a batch of user properties your
+   * remote config targeting depends on. You do NOT need to call it after
+   * {@link identify} — the SDK invalidates the cache on identity changes
+   * automatically. Call it after {@link initialize}.
+   */
+  invalidateRemoteConfigsCache(): void;
+
+  /**
    * This function should be used for the test purposes only. Do not forget to delete the usage of this function before the release.
    * Use this function to attach the user to the experiment.
    * @param experimentId identifier of the experiment

--- a/src/internal/QonversionInternal.ts
+++ b/src/internal/QonversionInternal.ts
@@ -376,6 +376,10 @@ export default class QonversionInternal implements QonversionApi {
     return mappedRemoteConfigList;
   }
 
+  invalidateRemoteConfigsCache() {
+    RNQonversion.invalidateRemoteConfigsCache();
+  }
+
   async attachUserToExperiment(experimentId: string, groupId: string): Promise<void> {
     await RNQonversion.attachUserToExperiment(experimentId, groupId);
     return;

--- a/src/internal/__tests__/QonversionInternal.test.ts
+++ b/src/internal/__tests__/QonversionInternal.test.ts
@@ -25,6 +25,7 @@ jest.mock('../specs/NativeQonversionModule', () => ({
     }),
     onPromoPurchaseReceived: jest.fn(),
     purchaseWithResult: jest.fn(),
+    invalidateRemoteConfigsCache: jest.fn(),
   },
 }));
 
@@ -250,5 +251,15 @@ describe('QonversionInternal - setDeferredPurchasesListener replaces wrapped ent
     instance.setDeferredPurchasesListener(newListener);
 
     expect(RNQonversion.onDeferredPurchaseCompleted).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('invalidateRemoteConfigsCache', () => {
+  it('passes the call straight through to the native module', () => {
+    const instance = new QonversionInternal(createConfig());
+
+    instance.invalidateRemoteConfigsCache();
+
+    expect(RNQonversion.invalidateRemoteConfigsCache).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/internal/specs/NativeQonversionModule.ts
+++ b/src/internal/specs/NativeQonversionModule.ts
@@ -73,6 +73,7 @@ export interface Spec extends TurboModule {
   remoteConfig(contextKey: string | undefined): Promise<QRemoteConfig>;
   remoteConfigList(): Promise<QRemoteConfigList>;
   remoteConfigListForContextKeys(contextKeys: string[], includeEmptyContextKey: boolean): Promise<QRemoteConfigList>;
+  invalidateRemoteConfigsCache(): void;
   attachUserToExperiment(experimentId: string, groupId: string): Promise<void>;
   detachUserFromExperiment(experimentId: string): Promise<void>;
   attachUserToRemoteConfiguration(remoteConfigurationId: string): Promise<void>;


### PR DESCRIPTION
B4 exposure from the Remote Config targeting review ([dash-mono PR #674](https://github.com/qonversion/dash-mono/pull/674)). Linear: [DEV-1236](https://linear.app/qonversion/issue/DEV-1236). Exposes the new cache invalidation API released in [android-sdk 9.7.0](https://github.com/qonversion/android-sdk/releases/tag/sdk%2F9.7.0) / [qonversion-ios-sdk 6.14.0](https://github.com/qonversion/qonversion-ios-sdk/releases/tag/6.14.0), bridged by [sandwich 7.12.0](https://github.com/qonversion/sandwich-sdk/releases/tag/7.12.0).

## What changed

1. **Sandwich pinned to 7.12.0** (Android + iOS). Note: the sandwich pod pins `Qonversion` exactly, so apps that also declare the native `Qonversion` pod directly must move to 6.14.0.
2. **New public API `invalidateRemoteConfigsCache`** — a void no-callback pass-through to the native method. It performs no network request; it marks the remote configs cache stale so the next `remoteConfig` / `remoteConfigList` call fetches a fresh targeting evaluation. An in-flight `remoteConfig` load is re-issued once so its waiting calls receive a fresh evaluation (degrading to the superseded one if the retry fails); an in-flight `remoteConfigList` completes with the evaluation it started with. You do NOT need to call it after `identify` — the SDK invalidates on identity changes automatically. Call it after initialization (calling before initialization crashes on Android and no-ops on iOS, same as the other void bridges).

## Release notes for this wrapper (minor bump)
- Source-breaking note for the release: `QonversionApi` gained a new required member — custom implementations and hand-written mocks must add `invalidateRemoteConfigsCache`.


- New: `invalidateRemoteConfigsCache` — invalidate the remote configs cache on demand (e.g. after setting a batch of user properties your targeting depends on).
- Native SDKs updated: Android 9.7.0, iOS 6.14.0 — automatic remote configs cache invalidation on same-uid `identify`, never-worse re-issue of superseded in-flight loads, uncached bundled fallbacks with rate-limit tolerance (remote configs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4V5cx2SMU4VrfPntwfKJ9
