### PR TITLE
feat: expose frozen Remote Config assignments

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,10 +8,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         name: Checkout
         
       - uses: borales/actions-yarn@v3.0.0
         name: Validation
         with:
           cmd: install
+
+      - name: Verify frozen assignment mapping
+        run: yarn test src/internal/__tests__/Mapper.test.ts --runInBand

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,5 +34,8 @@ jobs:
           yarn
           yarn prepare
 
+      - name: Verify frozen assignment mapping
+        run: yarn test src/internal/__tests__/Mapper.test.ts --runInBand
+
       - name: Publish to npm
         run: npm publish

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -80,7 +80,7 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "io.qonversion:sandwich:7.12.0"
+  implementation "io.qonversion:sandwich:7.13.0"
 }
 
 if (isNewArchitectureEnabled()) {

--- a/qonversion-react-native-sdk.podspec
+++ b/qonversion-react-native-sdk.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,cpp,swift}"
   s.private_header_files = "ios/**/*.h"
 
-  s.dependency "QonversionSandwich", "7.12.0"
+  s.dependency "QonversionSandwich", "7.13.0"
   install_modules_dependencies(s)
 end

--- a/src/dto/enums.ts
+++ b/src/dto/enums.ts
@@ -299,6 +299,7 @@ export enum RemoteConfigurationAssignmentType {
   UNKNOWN = "unknown",
   AUTO = "auto",
   MANUAL = "manual",
+  FROZEN = "frozen",
 }
 
 export enum ScreenPresentationStyle {

--- a/src/internal/Mapper.ts
+++ b/src/internal/Mapper.ts
@@ -1059,6 +1059,8 @@ class Mapper {
         return RemoteConfigurationAssignmentType.AUTO;
       case "manual":
         return RemoteConfigurationAssignmentType.MANUAL;
+      case "frozen":
+        return RemoteConfigurationAssignmentType.FROZEN;
       default:
         return RemoteConfigurationAssignmentType.UNKNOWN;
     }

--- a/src/internal/__tests__/Mapper.test.ts
+++ b/src/internal/__tests__/Mapper.test.ts
@@ -1,0 +1,13 @@
+import Mapper from '../Mapper';
+import { RemoteConfigurationAssignmentType } from '../../dto/enums';
+
+describe('remote configuration assignment provenance', () => {
+  it('preserves frozen and keeps unknown values fail-safe', () => {
+    expect(Mapper.convertRemoteConfigurationAssignmentType('frozen')).toBe(
+      RemoteConfigurationAssignmentType.FROZEN
+    );
+    expect(Mapper.convertRemoteConfigurationAssignmentType('future')).toBe(
+      RemoteConfigurationAssignmentType.UNKNOWN
+    );
+  });
+});


### PR DESCRIPTION
Adds `frozen` assignment provenance to the React Native bridge and pins Sandwich 7.13.0. Draft/stacked: merge only after qonversion/sandwich-sdk#357 is published. The existing Frozen/Unknown mapper contract now runs in pull-request CI and again before package publication. Verified locally with the focused Jest mapper suite and TypeScript typecheck.
